### PR TITLE
Issue 37 - Add featureId information instead of line number if available

### DIFF
--- a/validator-core/src/main/java/fr/ign/validator/Context.java
+++ b/validator-core/src/main/java/fr/ign/validator/Context.java
@@ -423,6 +423,18 @@ public class Context {
 	}
 
 	/**
+	 * Get current identifiant
+	 * @return
+	 */
+	public String getFeatureId() {
+		Row row = getDataByType(Row.class);
+		if (row != null) {
+			return row.getFeatureId();
+		}
+		return "";
+	}
+
+	/**
 	 * End data validation (pop data from dataStack)
 	 * @param location
 	 */
@@ -499,6 +511,7 @@ public class Context {
 		 * Add data informations (new)
 		 */
 		validatorError.setFeatureBbox(getFeatureBBox());
+	    validatorError.setFeatureId(getFeatureId());
 
 		return validatorError;
 	}

--- a/validator-core/src/main/java/fr/ign/validator/data/Row.java
+++ b/validator-core/src/main/java/fr/ign/validator/data/Row.java
@@ -40,6 +40,8 @@ public class Row implements Validatable {
 	 */
 	private Envelope featureBbox;
 
+	private String featureId;
+
 	/**
 	 * 
 	 * @param line
@@ -71,10 +73,32 @@ public class Row implements Validatable {
 		this.featureBbox = featureBbox;
 	}
 
+	public String getFeatureId() {
+		return featureId;
+	}
+
+	public void setFeatureId(String featureId) {
+		this.featureId = featureId;
+	}
+
 	@Override
 	public void validate(Context context) {
 		context.beginData(this);
 		FeatureType featureType = mapping.getFeatureType() ;
+
+	    /*
+	     * Looking for featureId if exist
+	     */
+	    for (int i = 0; i < featureType.getAttributeCount(); i++) {
+	      AttributeType<?> attributeType = featureType.getAttribute(i);
+	      if (attributeType.isIdentifiant()) {
+	        // update row feature id
+	        // can be retrieve from context (row in datastack)
+	        if (mapping.getAttributeIndex(i) >= 0) {
+	          this.featureId = values[mapping.getAttributeIndex(i)];
+	        }
+	      }
+	    }
 
 		/**
 		 * Looking for geometry if exist

--- a/validator-core/src/main/java/fr/ign/validator/error/ValidatorError.java
+++ b/validator-core/src/main/java/fr/ign/validator/error/ValidatorError.java
@@ -67,6 +67,11 @@ public class ValidatorError implements Cloneable {
 	 * WKT geometry error
 	 */
 	private String errorGeometry;
+	
+	/**
+	 * Feature identifiant is available
+	 */
+	private String featureId;
 
 	/**
 	 * @param code
@@ -214,6 +219,15 @@ public class ValidatorError implements Cloneable {
 	 */
 	public ValidatorError setErrorGeometry(String errorGeometry) {
 		this.errorGeometry = errorGeometry;
+		return this;
+	}
+
+	public String getFeatureId() {
+		return featureId;
+	}
+
+	public ValidatorError setFeatureId(String featureId) {
+		this.featureId = featureId;
 		return this;
 	}
 

--- a/validator-core/src/main/java/fr/ign/validator/model/AttributeType.java
+++ b/validator-core/src/main/java/fr/ign/validator/model/AttributeType.java
@@ -51,6 +51,10 @@ public abstract class AttributeType<T> implements Model, Cloneable {
 	 * Restriction on a list of values
 	 */
 	private List<String> listOfValues ;
+	/**
+	 * Indicates if the value represent the feature id
+	 */
+	private boolean identifiant;
 
 	/**
 	 * Validators on attributes
@@ -207,6 +211,13 @@ public abstract class AttributeType<T> implements Model, Cloneable {
 		return this.validators ;
 	}
 
+	public boolean isIdentifiant() {
+		return identifiant;
+	}
+
+	public void setIdentifiant(boolean identifiant) {
+		this.identifiant = identifiant;
+	}
 	
 	@Override
 	public String toString() {

--- a/validator-core/src/main/java/fr/ign/validator/xml/binding/AttributeTypeAdapter.java
+++ b/validator-core/src/main/java/fr/ign/validator/xml/binding/AttributeTypeAdapter.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 import fr.ign.validator.model.AttributeType;
 
-@XmlType(propOrder = { "name", "type", "definition", "regexp", "size", "nullable", "listOfValues" })
+@XmlType(propOrder = { "name", "type", "definition", "regexp", "size", "nullable", "listOfValues", "identifiant" })
 public class AttributeTypeAdapter extends XmlAdapter<AttributeTypeAdapter.AdaptedAttributeType, AttributeType<?>>{
 
 	@Override
@@ -17,7 +17,7 @@ public class AttributeTypeAdapter extends XmlAdapter<AttributeTypeAdapter.Adapte
 		if ( null == attributeType ){
 			return null ;
 		}
-		
+
 		AdaptedAttributeType adaptedAttributeType = new AdaptedAttributeType();
 		adaptedAttributeType.name = attributeType.getName() ;
 		adaptedAttributeType.type = attributeType.getTypeName() ;
@@ -26,16 +26,17 @@ public class AttributeTypeAdapter extends XmlAdapter<AttributeTypeAdapter.Adapte
 		adaptedAttributeType.size = attributeType.getSize() ;
 		adaptedAttributeType.nullable = attributeType.isNullable() ;
 		adaptedAttributeType.listOfValues = attributeType.getListOfValues() ;
+		adaptedAttributeType.identifiant = attributeType.isIdentifiant();
 		return adaptedAttributeType ;
 	}
 
-	
+
 	@Override
 	public AttributeType<?> unmarshal(AttributeTypeAdapter.AdaptedAttributeType adaptedValueType) throws Exception {
 		if ( null == adaptedValueType ){
 			return null ;
 		}
-		
+
 		AttributeType<?> attributeType = AttributeType.forName( adaptedValueType.type ) ;
 		attributeType.setName(adaptedValueType.name);
 		attributeType.setDefinition(adaptedValueType.definition);
@@ -43,7 +44,8 @@ public class AttributeTypeAdapter extends XmlAdapter<AttributeTypeAdapter.Adapte
 		attributeType.setSize(adaptedValueType.size);
 		attributeType.setNullable(adaptedValueType.nullable) ;
 		attributeType.setListOfValues(adaptedValueType.listOfValues);
-		
+		attributeType.setIdentifiant(adaptedValueType.identifiant);
+
 		return attributeType ;
 	}
 
@@ -54,6 +56,7 @@ public class AttributeTypeAdapter extends XmlAdapter<AttributeTypeAdapter.Adapte
 		public String regexp ;
 		public Integer size ;
 		public boolean nullable ;
+		public boolean identifiant;
 		@XmlElementWrapper(name = "listOfValues")
 		@XmlElement(name = "value")
 		public List<String> listOfValues ;

--- a/validator-core/src/test/java/fr/ign/validator/xml/binding/FeatureTypeTest.java
+++ b/validator-core/src/test/java/fr/ign/validator/xml/binding/FeatureTypeTest.java
@@ -62,6 +62,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals("String",attributeType.getTypeName());
 			assertEquals(false, attributeType.isNullable());
 			assertEquals("[0-9]{5}", attributeType.getRegexp());
+			assertEquals(false, attributeType.isIdentifiant());
 			assertNull(attributeType.getListOfValues());
 		}
 		{
@@ -70,6 +71,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals("String",attributeType.getTypeName());
 			assertEquals(false, attributeType.isNullable());
 			assertNull(attributeType.getRegexp());
+			assertEquals(false, attributeType.isIdentifiant());
 			assertNotNull(attributeType.getListOfValues());
 			assertEquals("01,02", Strings.join(attributeType.getListOfValues(),','));
 		}
@@ -79,6 +81,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals("Boolean",attributeType.getTypeName());
 			assertEquals(true, attributeType.isNullable());
 			assertNull(attributeType.getRegexp());
+			assertEquals(false, attributeType.isIdentifiant());
 			assertNull(attributeType.getListOfValues());
 		}
 		
@@ -109,6 +112,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals( "Integer", attribute.getTypeName() ) ;
 			assertNull( attribute.getRegexp() ) ;
 			assertFalse(attribute.isNullable()) ;
+			assertEquals(false, attribute.isIdentifiant());
 			assertNull(attribute.getListOfValues());
 		}
 
@@ -118,6 +122,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals( "String", attribute.getTypeName() ) ;
 			assertNull( attribute.getRegexp() ) ;
 			assertFalse(attribute.isNullable()) ;
+			assertEquals(false, attribute.isIdentifiant());
 
 			assertNull(attribute.getListOfValues());
 		}
@@ -127,6 +132,7 @@ public class FeatureTypeTest extends TestCase {
 			assertEquals( "GEOMETRY", attribute.getName() ) ;
 			assertEquals( "Geometry", attribute.getTypeName() ) ;
 			assertTrue(attribute.isNullable()) ;
+			assertEquals(false, attribute.isIdentifiant());
 			assertNull(attribute.getListOfValues());
 		}
 		

--- a/validator-core/src/test/resources/report/report-01.jsonl
+++ b/validator-core/src/test/resources/report/report-01.jsonl
@@ -1,2 +1,2 @@
-{"code":"ATTRIBUTE_FILE_NOT_FOUND","scope":"DIRECTORY","level":"DEBUG","message":"message 1","documentModel":null,"fileModel":null,"attribute":null,"file":null,"id":null,"featureBbox":null,"errorGeometry":null}
-{"code":"ATTRIBUTE_GEOMETRY_INVALID","scope":"DIRECTORY","level":"DEBUG","message":"message 2","documentModel":null,"fileModel":null,"attribute":null,"file":null,"id":null,"featureBbox":null,"errorGeometry":null}
+{"code":"ATTRIBUTE_FILE_NOT_FOUND","scope":"DIRECTORY","level":"DEBUG","message":"message 1","documentModel":null,"fileModel":null,"attribute":null,"file":null,"id":null,"featureBbox":null,"errorGeometry":null,"featureId":null}
+{"code":"ATTRIBUTE_GEOMETRY_INVALID","scope":"DIRECTORY","level":"DEBUG","message":"message 2","documentModel":null,"fileModel":null,"attribute":null,"file":null,"id":null,"featureBbox":null,"errorGeometry":null,"featureId":null}

--- a/validator-core/src/test/resources/xml/sample-document/types/COMMUNE.xml
+++ b/validator-core/src/test/resources/xml/sample-document/types/COMMUNE.xml
@@ -8,11 +8,13 @@
             <type>String</type>
             <regexp>[0-9]{5}</regexp>
             <nullable>false</nullable>
+            <identifiant>false</identifiant>
         </attribute>
         <attribute>
             <name>CODE_DEPT</name>
             <type>String</type>
             <nullable>false</nullable>
+            <identifiant>false</identifiant>
             <listOfValues>
                 <value>01</value>
                 <value>02</value>
@@ -22,6 +24,7 @@
             <name>DETRUIT</name>
             <type>Boolean</type>
             <nullable>true</nullable>
+            <identifiant>false</identifiant>
         </attribute>
     </attributes>
 </featureType>


### PR DESCRIPTION
ValidatorCore: add featureId information in validation report

- **Context**: Add featureId information when an error is report
- **Row**: featureId is detected before any content validation
- **validatorError**: featureId new attribute to save new information in validation report
- **AttributeType**: identifiant new attribute tels if the attribute give feature identifiant
- **AttributeTypeAdapter**: AttributeType identifiant is read from configuration file
- **FeatureTypeTest**: Test new identifiant attribute
- **Ressources**: update report test with new ValidationError model, update unmarshal sample document file model

@see #37 