### PR TITLE
proxy_auth - add hability to use http proxy with authentication

### DIFF
--- a/validator-core/src/main/java/fr/ign/validator/command/AbstractCommand.java
+++ b/validator-core/src/main/java/fr/ign/validator/command/AbstractCommand.java
@@ -1,5 +1,6 @@
 package fr.ign.validator.command;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.cli.CommandLine;
@@ -9,6 +10,8 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
+import fr.ign.validator.tools.ProxyParser;
 
 /**
  * 
@@ -119,16 +122,22 @@ public abstract class AbstractCommand implements Command {
 	 */
 	protected void parseProxyOption(CommandLine commandLine) throws ParseException{
 		proxy = commandLine.getOptionValue("proxy", "");
-		if (!proxy.isEmpty()) {
-			String[] proxyParts = proxy.split(":");
-			if (proxyParts.length != 2) {
-				throw new ParseException("Invalid 'proxy' parameter (<proxy-host>:<proxy-port>)");
-			}
-			Properties systemSettings = System.getProperties();
-			systemSettings.put("proxySet", "true");
-			systemSettings.put("http.proxyHost", proxyParts[0]);
-			systemSettings.put("http.proxyPort", proxyParts[1]);
+		configureHttpClient();
+	}
+
+	/**
+	 * Configure network options including proxy
+	 * @throws ParseException
+	 */
+	private void configureHttpClient() throws ParseException {
+		/* configure network */
+		Properties systemSettings = System.getProperties();
+		Map<String,String> properties = ProxyParser.parse(proxy);
+		for ( String key : properties.keySet() ){
+			systemSettings.put(key, properties.get(key));
 		}
+		/* configure SSL */
+		systemSettings.put("https.protocols", "TLSv1,TLSv1.1,TLSv1.2");
 	}
 
 }

--- a/validator-core/src/main/java/fr/ign/validator/command/ReadUrlCommand.java
+++ b/validator-core/src/main/java/fr/ign/validator/command/ReadUrlCommand.java
@@ -1,0 +1,69 @@
+package fr.ign.validator.command;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
+/**
+ * 
+ * Read URL to check proxy configuration
+ * 
+ * @author MBorne
+ */
+public class ReadUrlCommand extends AbstractCommand {
+
+	public static final Logger log = LogManager.getRootLogger();
+	public static final Marker MARKER = MarkerManager.getMarker("ReadUrlCommand");
+	
+	
+	public static final String NAME = "read_url";
+
+	private String url ;
+	
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public void execute() throws Exception {
+		URL url = new URL(this.url);
+		InputStream in = url.openStream();
+		try {
+			InputStreamReader inR = new InputStreamReader(in);
+			BufferedReader buf = new BufferedReader(inR);
+			String line;
+			while ((line = buf.readLine()) != null) {
+				System.out.println(line);
+			}
+		} finally {
+			in.close();
+		}
+	}
+
+	@Override
+	protected void buildCustomOptions(Options options) {
+		{
+			Option option = new Option("url", "url", true, "URL to test");
+			option.setRequired(true);
+			options.addOption(option);
+		}
+	}
+
+	@Override
+	protected void parseCustomOptions(CommandLine commandLine) throws ParseException {
+		this.url = commandLine.getOptionValue("url");
+		log.info("URL : {}",this.url);
+	}
+
+}

--- a/validator-core/src/main/java/fr/ign/validator/tools/ProxyParser.java
+++ b/validator-core/src/main/java/fr/ign/validator/tools/ProxyParser.java
@@ -1,0 +1,116 @@
+package fr.ign.validator.tools;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Parse proxy string to get compatibility with HTTP_PROXY environment variables
+ * 
+ * @author MBorne
+ *
+ */
+public class ProxyParser {
+
+	/**
+	 * Parse proxy provided as a single string with one of the following format 
+	 * 
+	 * <ul>
+	 * 	<li>{proxyHost}:{proxyPort}</li>
+	 *  <li>http://{proxyHost}:{proxyPort}</li>
+	 *  <li>http://{proxyUser}:{proxyPassword}@{proxyHost}:{proxyPort}</li>  
+	 * </ul>
+	 * 
+	 * @param proxy
+	 * @return the corresponding system properties
+	 * @throws ParseException
+	 */
+	public static Map<String,String> parse(String proxy) throws ParseException{
+		if ( StringUtils.isEmpty(proxy) ){
+			return new HashMap<>();
+		}
+		if ( ! proxy.contains("://") ){
+			return parseProxyHost(proxy);
+		}else{
+			return parseUrl(proxy);
+		}
+	}
+
+	/**
+	 * Parse legacy {proxyHost}:{proxyPort}
+	 * @param proxy
+	 * @param properties
+	 * @return
+	 * @throws ParseException
+	 */
+	private static Map<String, String> parseProxyHost(
+		String proxy
+	) throws ParseException {
+		Map<String,String> properties = new HashMap<String,String>();
+		if ( StringUtils.isEmpty(proxy) ){
+			return properties;
+		}
+		String[] proxyParts = proxy.split(":");
+		if (proxyParts.length != 2) {
+			throw new ParseException("Invalid proxy, expecting {proxyUser}:{proxyPassword} or URL");
+		}
+		properties.put("proxySet", "true");
+		properties.put("http.proxyHost", proxyParts[0]);
+		properties.put("http.proxyPort", proxyParts[1]);
+		properties.put("https.proxyHost", proxyParts[0]);
+		properties.put("https.proxyPort", proxyParts[1]);
+		return properties;
+	}
+
+
+	/**
+	 * Parse proxy define as an URL
+	 * @param proxy
+	 * @param properties
+	 * @return
+	 * @throws ParseException
+	 */
+	private static Map<String, String> parseUrl(
+		String proxy
+	) throws ParseException {
+		Map<String,String> properties = new HashMap<String,String>();
+		if ( StringUtils.isEmpty(proxy) ){
+			return properties;
+		}
+		try {
+			URI uri = new URI(proxy);
+			if ( uri.getPort() < 1 || StringUtils.isEmpty(uri.getHost()) ){
+				throw new ParseException("Invalid proxy URL");
+			}
+			if ( ! uri.getScheme().equals("http") ){
+				throw new ParseException("Invalid proxy URL (expecting http protocol)");
+			}
+
+			properties.put("proxySet", "true");
+			properties.put("http.proxyHost", uri.getHost());
+			properties.put("http.proxyPort", ""+uri.getPort());
+			properties.put("https.proxyHost", uri.getHost());
+			properties.put("https.proxyPort", ""+uri.getPort());
+
+			String userInfo = uri.getUserInfo();
+			if ( ! StringUtils.isEmpty(userInfo) ){
+				String[] userInfoParts = userInfo.split(":");
+				if (userInfoParts.length != 2) {
+					throw new ParseException("Invalid proxy user");
+				}
+				properties.put("http.proxyUser", userInfoParts[0]);
+				properties.put("http.proxyPassword", ""+userInfoParts[1]);
+				properties.put("https.proxyUser", userInfoParts[0]);
+				properties.put("https.proxyPassword", ""+userInfoParts[1]);
+			}
+			return properties;
+		}catch(URISyntaxException e){
+			throw new ParseException("Invalid proxy, expecting {proxyUser}:{proxyPassword} or URL");
+		}
+	}
+
+}

--- a/validator-core/src/main/resources/META-INF/services/fr.ign.validator.command.Command
+++ b/validator-core/src/main/resources/META-INF/services/fr.ign.validator.command.Command
@@ -2,4 +2,5 @@ fr.ign.validator.command.DocumentValidatorCommand
 fr.ign.validator.command.MetadataToJsonCommand
 fr.ign.validator.command.UnicodeTableCommand
 fr.ign.validator.command.ProjectionListCommand
+fr.ign.validator.command.ReadUrlCommand
 

--- a/validator-core/src/test/java/fr/ign/validator/tools/ProxyParserTest.java
+++ b/validator-core/src/test/java/fr/ign/validator/tools/ProxyParserTest.java
@@ -1,0 +1,90 @@
+package fr.ign.validator.tools;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.apache.commons.cli.ParseException;
+import org.junit.Test;
+
+public class ProxyParserTest {
+
+	@Test
+	public void testNull() throws ParseException {
+		Map<String,String> properties = ProxyParser.parse(null);
+		assertTrue(properties.isEmpty());
+	}
+
+	@Test
+	public void testEmpty() throws ParseException {
+		Map<String,String> properties = ProxyParser.parse("");
+		assertTrue(properties.isEmpty());
+	}
+
+	@Test
+	public void testHostPort() throws ParseException {
+		Map<String,String> properties = ProxyParser.parse("proxy.ign.fr:3128");
+		assertFalse(properties.isEmpty());
+		
+		assertEquals("true",properties.get("proxySet"));
+		assertEquals("proxy.ign.fr",properties.get("http.proxyHost"));
+		assertEquals("3128",properties.get("http.proxyPort"));
+		assertEquals("proxy.ign.fr",properties.get("https.proxyHost"));
+		assertEquals("3128",properties.get("https.proxyPort"));		
+		assertEquals(5, properties.keySet().size());
+	}
+
+	@Test
+	public void testHttpHostPort() throws ParseException {
+		Map<String,String> properties = ProxyParser.parse("http://proxy.ign.fr:3128");
+		assertFalse(properties.isEmpty());
+		
+		assertEquals("true",properties.get("proxySet"));
+		assertEquals("proxy.ign.fr",properties.get("http.proxyHost"));
+		assertEquals("3128",properties.get("http.proxyPort"));
+		assertEquals("proxy.ign.fr",properties.get("https.proxyHost"));
+		assertEquals("3128",properties.get("https.proxyPort"));		
+		assertEquals(5, properties.keySet().size());
+	}
+	
+	
+	@Test
+	public void testHttpUserPasswordHostPort() throws ParseException {
+		Map<String,String> properties = ProxyParser.parse("http://username:userpass@proxy.ign.fr:3128");
+		assertFalse(properties.isEmpty());
+		
+		assertEquals("true",properties.get("proxySet"));
+		assertEquals("proxy.ign.fr",properties.get("http.proxyHost"));
+		assertEquals("3128",properties.get("http.proxyPort"));
+		assertEquals("username",properties.get("http.proxyUser"));
+		assertEquals("userpass",properties.get("http.proxyPassword"));
+
+		assertEquals("proxy.ign.fr",properties.get("https.proxyHost"));
+		assertEquals("3128",properties.get("https.proxyPort"));
+		assertEquals("username",properties.get("https.proxyUser"));
+		assertEquals("userpass",properties.get("https.proxyPassword"));
+		
+		assertEquals(9, properties.keySet().size());
+	}
+
+	@Test
+	public void testInvalidUrl() throws ParseException {
+		assertThrowForInvalid("http://invalid-no-port.fr");
+		assertThrowForInvalid("http:///invalid-no-port.fr:3128");
+		assertThrowForInvalid("ftp://invalid-not-http.fr:3128");
+		assertThrowForInvalid("https:///invalid-not-http.fr:3128");		
+	}
+
+	private void assertThrowForInvalid(String input) {
+		boolean thrown = false;
+		try {
+			ProxyParser.parse(input);
+		}catch(ParseException e){
+			thrown = true;
+		}
+		assertTrue("Should have thrown exception for : "+input, thrown);
+	}
+
+}


### PR DESCRIPTION
Ajout du support de : 

* `--proxy=http://{proxyHost}:{proxyPort}`
* `--proxy=http://{proxyUser}:{proxyPassword}@{proxyHost}:{proxyPort}`

Conservation de : 

* `--proxy={proxyHost}:{proxyPort}`

Remarque : J'ajoute une commande "read_url" pour pouvoir tester plus facilement lors des déploiements

