### PR TITLE
Prepare integration of database validator in validator-core (closes #107)

### DIFF
--- a/validator-plugin-dgpr/src/main/java/fr/ign/validator/dgpr/validation/database/IdentifierValidator.java
+++ b/validator-plugin-dgpr/src/main/java/fr/ign/validator/dgpr/validation/database/IdentifierValidator.java
@@ -15,7 +15,6 @@ import fr.ign.validator.database.RowIterator;
 import fr.ign.validator.dgpr.error.DgprErrorCodes;
 import fr.ign.validator.error.ErrorScope;
 import fr.ign.validator.model.AttributeType;
-import fr.ign.validator.model.FeatureType;
 import fr.ign.validator.model.FileModel;
 import fr.ign.validator.model.file.TableModel;
 import fr.ign.validator.validation.Validator;
@@ -62,22 +61,25 @@ public class IdentifierValidator implements Validator<Database> {
             if (!(fileModel instanceof TableModel)) {
                 continue;
             }
-
-            FeatureType featureType = fileModel.getFeatureType();
-
-            List<AttributeType<?>> attributesList = featureType.getAttributes();
+            
+            // TODO context.beginModel(fileModel)
 
             // Looking for attributes who are identifiers
-            for (AttributeType<?> attribute : attributesList) {
+            for (AttributeType<?> attribute : fileModel.getFeatureType().getAttributes()) {
                 if (!attribute.isIdentifier()) {
                     continue;
                 }
+                // TODO context.beginModel(attribute)
                 validateOneIdentifier(attribute.getName(), fileModel);
+                // TODO context.endModel(attribute)
             }
+            // TODO context.endModel(fileModel)
         }
     }
 
     private void validateOneIdentifier(String identifier, FileModel fileModel) throws SQLException, IOException {
+        // TODO HAVING count(*) > 1 ORDER BY count(*) DESC
+        // TODO LIMIT 10 ?
         RowIterator table = database.query(
             "SELECT " + identifier + " AS id, Count(" + identifier + ") AS count "
                 + " FROM " + fileModel.getName()
@@ -92,6 +94,7 @@ public class IdentifierValidator implements Validator<Database> {
             int compte = Integer.parseInt(row[indexCount]);
 
             // if not unique, send error
+            // remove condition by adding HAVING count(*) > 1
             if (compte > 1) {
                 context.report(
                     context.createError(DgprErrorCodes.DGPR_IDENTIFIER_UNICITY)


### PR DESCRIPTION
Incoming pull request to close this issue :

* [x] Clarify SQL table creation (explicit content reset, hability to use Database#createDatabase without table creation)
* [x] Create sqlite database in validation directory (validation/document_database.db)
* [x] Ensure that tests doesn't fail using a postgis database

```
# prepare test database
dropdb validator-test
createdb validator-test
psql -d validator-test -c "CREATE EXTENSION postgis"

# build running test
export DB_URL=jdbc:postgresql:validator-test
export DB_USER=postgis
export DB_PASSWORD=postgis
#export DB_SCHEMA=validation
mvn clean package
```

* [x] Create a dedicated issue #174 to handle changes such as `DPGR_IDENTIFIER_UNICITY` -> `ATTRIBUTE_NOT_UNIQUE` 
